### PR TITLE
add past tab page, fix timer, add session control buttons

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -5,12 +5,13 @@ export default function Alert(props) {
   let closeAlert = (confirmed) => {
     props.setIsVisible(false)
     if (props.confirmationCallback !== undefined && confirmed === true) {
+      props.wipeCallbackWithoutConfirmation()
       props.confirmationCallback()
     }
     props.wipeCallback()
   }
 
-  let footer = props.confirmationCallback !== undefined
+  let footer = props.confirmationCallback !== undefined && props.callbackWithoutConfirmation !== true
     ? (
         <div className="w-full h-full border-t bg-white rounded-b rounded-t">
           <button onClick={() => closeAlert(false)} className="w-1/2 h-full border-r hover:bg-gray-100 focus:bg-gray-200">

--- a/src/App.js
+++ b/src/App.js
@@ -9,19 +9,25 @@ function App() {
   const [isAlertVisible, setIsAlertVisible] = React.useState(false);
   const [alertText, setAlertText] = React.useState("");
   const [confirmationCallback, setConfirmationCallback] = React.useState(() => {})
+  const [callbackWithoutConfirmation, setCallbackWithoutConfirmation] = React.useState(false)
 
   let wipeCallback = () => {
     setConfirmationCallback(() => {})
   }
 
+  let wipeCallbackWithoutConfirmation = () => {
+    setCallbackWithoutConfirmation(false)
+  }
+
   return (
     <div>
-      <Alert wipeCallback={wipeCallback} isVisible={isAlertVisible} setIsVisible={setIsAlertVisible} text={alertText} confirmationCallback={confirmationCallback}/>
+      <Alert wipeCallback={wipeCallback} isVisible={isAlertVisible} setIsVisible={setIsAlertVisible} text={alertText} confirmationCallback={confirmationCallback}
+        callbackWithoutConfirmation={callbackWithoutConfirmation} wipeCallbackWithoutConfirmation={wipeCallbackWithoutConfirmation}/>
       <Router>
         <Switch>
         <Route path='/session' 
             render={(props) => (
-              <Session {...props} isAlertVisible={isAlertVisible} setIsAlertVisible={setIsAlertVisible} setAlertText={setAlertText} setConfirmationCallback={setConfirmationCallback}/>
+              <Session {...props} isAlertVisible={isAlertVisible} setIsAlertVisible={setIsAlertVisible} setAlertText={setAlertText} setConfirmationCallback={setConfirmationCallback} setCallbackWithoutConfirmation={setCallbackWithoutConfirmation}/>
             )}
           />
           <Route path='/' 

--- a/src/session/Session.js
+++ b/src/session/Session.js
@@ -56,7 +56,7 @@ export default function Session(props) {
   }
 
   let confirmTransitionToNextSection = () => {
-    props.setAlertText("Confirm transition to next seciton")
+    props.setAlertText("Confirm transition to next section")
     props.setConfirmationCallback(() => () => transitionToNextSection())
     props.setIsAlertVisible(true)
   }
@@ -109,7 +109,8 @@ export default function Session(props) {
         {connectToWebSocketServer
           ? <WebSocketClient sessionId={sessionId} setTopics={setTopics} setWebsocketUserId={setWebsocketUserId}
               sessionStatus={sessionStatus} setSessionStatus={setSessionStatus} setUsersInAttendance={setUsersInAttendance}
-              setIsAlertVisible={props.setIsAlertVisible} setAlertText={props.setAlertText}/>
+              setIsAlertVisible={props.setIsAlertVisible} setAlertText={props.setAlertText} setConfirmationCallback={props.setConfirmationCallback}
+              usersInAttendance={usersInAttendance} username={username} setCallbackWithoutConfirmation={props.setCallbackWithoutConfirmation}/>
           : null}
 
         <UseranmePromptModal sessionId={sessionId} websocketUserId={websocketUserId} setSessionStatus={setSessionStatus}

--- a/src/session/WebSocketClient.js
+++ b/src/session/WebSocketClient.js
@@ -19,6 +19,15 @@ class WebSocketClient extends React.Component {
         (frame) => {
           stompClient.subscribe('/topic/discussion-topics/session/' + this.props.sessionId, 
             (payload) => {
+              if(payload.body === "") {
+                if(!this.props.usersInAttendance.moderator.includes(this.props.username)) {
+                  this.props.setAlertText("The moderator has ended the session. All session data has been deleted. Click OK to be redirected or close the window to exit")
+                  this.props.setConfirmationCallback(() => () => {return window.location = process.env.REACT_APP_FRONTEND_BASEURL})
+                  this.props.setCallbackWithoutConfirmation(true)
+                  this.props.setIsAlertVisible(true)
+                }
+              }
+
               this.props.setTopics(JSON.parse(payload.body));
 
               if(JSON.parse(payload.body).currentDiscussionItem.text !== undefined) {

--- a/src/session/WebSocketClient.js
+++ b/src/session/WebSocketClient.js
@@ -22,7 +22,6 @@ class WebSocketClient extends React.Component {
               this.props.setTopics(JSON.parse(payload.body));
 
               if(JSON.parse(payload.body).currentDiscussionItem.text !== undefined) {
-                this.props.setTopics(JSON.parse(payload.body));
                 if(this.props.sessionStatus !== "DISCUSSING") {
                   this.props.setSessionStatus("DISCUSSING");
                 }

--- a/src/session/discussion/Current.js
+++ b/src/session/discussion/Current.js
@@ -6,7 +6,7 @@ class Current extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      timerString: "3:00"
+      timerString: ""
     }
     this.confirmLoadNextTopic = this.confirmLoadNextTopic.bind(this)
     this.loadNextTopic = this.loadNextTopic.bind(this)
@@ -89,30 +89,23 @@ class Current extends React.Component {
       : this.props.topic.text
 
     return (
-      <>
-        { 
-          this.props.topic !== undefined && this.props.topic.text !== undefined ? 
-          (
-            <div className="h-full flex flex-col">
-              <div className="mt-2">
-                <h2>Current Discussion Topic</h2>
-              </div>
-              
-              <div className="overflow-scroll px-5 mt-2">
-                <h1>{mainText}</h1>
-              </div>
+      <div className="h-full flex flex-col">
+        <div className="mt-2">
+          <h2>Current Discussion Topic</h2>
+        </div>
+        
+        <div className="overflow-scroll px-5 mt-2">
+          <h1>{mainText}</h1>
+        </div>
 
-              <div className="flex flex-grow flex-col justify-end mt-3">
-                <div className="flex flex-row justify-between">
-                  {endTopicButton}
-                  <h2>{this.state.timerString}</h2>
-                  {endSessionButton}
-                </div>
-              </div>
-            </div> 
-          ) : <h2>All conversation topics completed!</h2>
-        }
-      </>
+        <div className="flex flex-grow flex-col justify-end mt-3">
+          <div className="flex flex-row justify-between">
+            {endTopicButton}
+            <h2>{this.state.timerString}</h2>
+            {endSessionButton}
+          </div>
+        </div>
+      </div>
     )
   }
 }

--- a/src/session/discussion/Current.js
+++ b/src/session/discussion/Current.js
@@ -1,25 +1,30 @@
 import React from 'react'
+import Axios from 'axios'
 
-export default function Current(props) {
+class Current extends React.Component {
 
-  const [timerString, setTimerString] = React.useState("")
+  constructor(props) {
+    super(props)
+    this.state = {
+      timerString: "3:00"
+    }
+    this.confirmLoadNextTopic = this.confirmLoadNextTopic.bind(this)
+    this.loadNextTopic = this.loadNextTopic.bind(this)
+  }
 
-  React.useEffect(() => timer())
-
-  let timer = () => {
+  componentDidMount() {
     setInterval(() => {
-      if (props.topic !== undefined && props.topic.endTime !== undefined) {
-        const timestamp = Date.parse(props.topic.endTime)
+      if (this.props.currentDiscussionItem !== undefined && this.props.currentDiscussionItem.endTime !== undefined) {
+        const timestamp = Date.parse(this.props.currentDiscussionItem.endTime)
         let secondsLeft = Math.max(0, Math.round((timestamp - Date.now()) / 1000))
-        let result = getTimerStringFromSecondsLeft(secondsLeft)
-        if (timerString !== result) {
-          setTimerString(result)
-        }
+        let result = this.getTimerStringFromSecondsLeft(secondsLeft)
+        this.setState({timerString: result})
       }
     }, 500);
   }
 
-  let getTimerStringFromSecondsLeft = (secondsLeft) => {
+
+  getTimerStringFromSecondsLeft(secondsLeft) {
     let min = Math.floor(secondsLeft / 60)
     let seconds = Math.floor(secondsLeft % 60)
     let sec = seconds.toString()
@@ -29,26 +34,65 @@ export default function Current(props) {
     return min + ':' + sec;
   }
 
-  return (
-    <>
-      { 
-        props.topic !== undefined && props.topic.text !== undefined ? 
-        (
-          <div className="h-full flex flex-col">
-            <div className="mt-2">
-              <h2>Current Discussion Topic</h2>
-            </div>
-            
-            <div className="overflow-scroll px-5 mt-2">
-              <h1>{props.topic.text}</h1>
-            </div>
+  confirmLoadNextTopic() {
+    this.props.setAlertText("End current topic?")
+    this.props.setConfirmationCallback(() => () => this.loadNextTopic());
+    this.props.setIsAlertVisible(true)
+  }
 
-            <div className="flex flex-grow flex-col justify-end mt-3">
-              <h2>{timerString}</h2>
-            </div>
-          </div> 
-        ) : <h2>All conversation topics completed!</h2>
-      }
-    </>
-  )
+  loadNextTopic() {
+    let nextTopic = this.props.discussionBacklogTopics === undefined || this.props.discussionBacklogTopics.length < 1
+      ? undefined
+      : this.props.discussionBacklogTopics[0]
+    
+    let body = nextTopic !== undefined
+      ? {command: "NEXT", sessionId: this.props.sessionId, currentTopicText: this.props.topic.text, nextTopicText: nextTopic.text, currentTopicAuthorDisplayName: this.props.topic.authorDisplayName, nextTopicAuthorDisplayName: nextTopic.authorDisplayName}
+      : {command: "FINISH", sessionId: this.props.sessionId, currentTopicText: this.props.topic.text, currentTopicAuthorDisplayName: this.props.topic.authorDisplayName};
+    
+    Axios.post(process.env.REACT_APP_BACKEND_BASEURL + "/refresh-topics", body)
+  }
+
+
+  render() {
+    let endTopicButton = this.props.isModerator === true && (this.props.topic !== undefined && this.props.topic.text !== undefined)
+      ? <button onClick={this.confirmLoadNextTopic} className="hover:bg-gray-900 focus:bg-black outline ml-1 p-1 text-sm">End Topic</button>
+      : <button onClick={this.confirmLoadNextTopic} className="invisible hover:bg-gray-900 focus:bg-black outline ml-1 p-1 text-sm">End Topic</button>
+
+    let endSessionButton = this.props.isModerator === true 
+      ? <button onClick={() => this.confirmLoadNextTopic(this.props.topic)} className="hover:bg-gray-900 focus:bg-black outline mr-1 p-1 text-sm">End Session</button>
+      : <button onClick={() => this.confirmLoadNextTopic(this.props.topic)} className="invisible hover:bg-gray-900 focus:bg-black outline mr-1 p-1 text-sm">End Session</button>
+
+    let mainText = this.props.topic === undefined || this.props.topic.text === undefined 
+      ? "All conversation topics completed!"
+      : this.props.topic.text
+
+    return (
+      <>
+        { 
+          this.props.topic !== undefined && this.props.topic.text !== undefined ? 
+          (
+            <div className="h-full flex flex-col">
+              <div className="mt-2">
+                <h2>Current Discussion Topic</h2>
+              </div>
+              
+              <div className="overflow-scroll px-5 mt-2">
+                <h1>{mainText}</h1>
+              </div>
+
+              <div className="flex flex-grow flex-col justify-end mt-3">
+                <div className="flex flex-row justify-between">
+                  {endTopicButton}
+                  <h2>{this.state.timerString}</h2>
+                  {endSessionButton}
+                </div>
+              </div>
+            </div> 
+          ) : <h2>All conversation topics completed!</h2>
+        }
+      </>
+    )
+  }
 }
+
+export default Current

--- a/src/session/discussion/Current.js
+++ b/src/session/discussion/Current.js
@@ -10,6 +10,8 @@ class Current extends React.Component {
     }
     this.confirmLoadNextTopic = this.confirmLoadNextTopic.bind(this)
     this.loadNextTopic = this.loadNextTopic.bind(this)
+    this.confirmEndSession = this.confirmEndSession.bind(this)
+    this.endSession = this.endSession.bind(this)
   }
 
   componentDidMount() {
@@ -22,7 +24,6 @@ class Current extends React.Component {
       }
     }, 500);
   }
-
 
   getTimerStringFromSecondsLeft(secondsLeft) {
     let min = Math.floor(secondsLeft / 60)
@@ -52,6 +53,27 @@ class Current extends React.Component {
     Axios.post(process.env.REACT_APP_BACKEND_BASEURL + "/refresh-topics", body)
   }
 
+  confirmEndSession() {
+    this.props.setAlertText("Are you sure you'd like to end the session?")
+    this.props.setConfirmationCallback(() => () => this.endSession());
+    this.props.setIsAlertVisible(true)
+  }
+
+  endSession() {
+    Axios.post(process.env.REACT_APP_BACKEND_BASEURL + '/end-session/' + this.props.sessionId, {})
+      .then((response) => {
+        if(response.data.status !== "SUCCESS") {
+          this.props.setAlertText("Invalid submission, please fix and retry")
+          this.props.setIsAlertVisible(true)        
+        } else {
+          return window.location = process.env.REACT_APP_FRONTEND_BASEURL;
+        }
+      })
+      .catch((error) => {
+        this.props.setAlertText("An error occurred, please try again")
+        this.props.setIsAlertVisible(true)
+      });
+  }
 
   render() {
     let endTopicButton = this.props.isModerator === true && (this.props.topic !== undefined && this.props.topic.text !== undefined)
@@ -59,8 +81,8 @@ class Current extends React.Component {
       : <button onClick={this.confirmLoadNextTopic} className="invisible hover:bg-gray-900 focus:bg-black outline ml-1 p-1 text-sm">End Topic</button>
 
     let endSessionButton = this.props.isModerator === true 
-      ? <button onClick={() => this.confirmLoadNextTopic(this.props.topic)} className="hover:bg-gray-900 focus:bg-black outline mr-1 p-1 text-sm">End Session</button>
-      : <button onClick={() => this.confirmLoadNextTopic(this.props.topic)} className="invisible hover:bg-gray-900 focus:bg-black outline mr-1 p-1 text-sm">End Session</button>
+      ? <button onClick={this.confirmEndSession} className="hover:bg-gray-900 focus:bg-black outline mr-1 p-1 text-sm">End Session</button>
+      : <button onClick={this.confirmEndSession} className="invisible hover:bg-gray-900 focus:bg-black outline mr-1 p-1 text-sm">End Session</button>
 
     let mainText = this.props.topic === undefined || this.props.topic.text === undefined 
       ? "All conversation topics completed!"

--- a/src/session/discussion/Discussion.js
+++ b/src/session/discussion/Discussion.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Current from './Current'
 import Queue from './Queue'
+import Past from './Past'
 
 export default function Discussion(props) {
 
@@ -32,7 +33,9 @@ export default function Discussion(props) {
                 isModerator={props.isModerator} setTopics={props.setBacklogTopics} setConfirmationCallback={props.setConfirmationCallback} 
                 currentDiscussionItem={props.topics.currentDiscussionItem}/>
             : activeTab === "PAST"
-              ? "PAST"
+              ? <Past setIsAlertVisible={props.setIsAlertVisible} setAlertText={props.setAlertText} setConfirmationCallback={props.setConfirmationCallback}
+                  topics={props.topics.discussedTopics} currentDiscussionItem={props.topics.currentDiscussionItem} sessionId={props.sessionId} isModerator={props.isModerator} 
+                  isAnyTopicActive={props.topics.currentDiscussionItem !== undefined && props.topics.currentDiscussionItem.text !== undefined}/>
               : <Current topic={props.topics.currentDiscussionItem}/>}
       </div>
     </div>

--- a/src/session/discussion/Discussion.js
+++ b/src/session/discussion/Discussion.js
@@ -22,9 +22,9 @@ export default function Discussion(props) {
   return (
     <div className="pb-2">
       <div>
-        <button onClick={() => setActiveTab("QUEUE")} className={queueButtonStyle + " relative mt-2 mx-2 p-1 rounded-tl rounded-tr"}>QUEUE</button>
-        <button onClick={() => setActiveTab("CURRENT")} className={currentButtonStyle + " relative mt-2 mx-2 p-1 rounded-tl rounded-tr"}>CURRENT</button>
-        <button onClick={() => setActiveTab("PAST")} className={pastButtonStyle + " relative mt-2 mx-2 p-1 rounded-tl rounded-tr"}>PAST</button>
+        <button onClick={() => setActiveTab("QUEUE")} className={queueButtonStyle + " relative mt-2 mx-2 p-1 rounded-tl rounded-tr hover:text-gray-300 focus:text-gray-400"}>QUEUE</button>
+        <button onClick={() => setActiveTab("CURRENT")} className={currentButtonStyle + " relative mt-2 mx-2 p-1 rounded-tl rounded-tr hover:text-gray-300 focus:text-gray-400"}>CURRENT</button>
+        <button onClick={() => setActiveTab("PAST")} className={pastButtonStyle + " relative mt-2 mx-2 p-1 rounded-tl rounded-tr hover:text-gray-300 focus:text-gray-400"}>PAST</button>
       </div>
 
       <div className="h-70vh sm:h-80vh m-auto w-85w border rounded">

--- a/src/session/discussion/Discussion.js
+++ b/src/session/discussion/Discussion.js
@@ -36,7 +36,9 @@ export default function Discussion(props) {
               ? <Past setIsAlertVisible={props.setIsAlertVisible} setAlertText={props.setAlertText} setConfirmationCallback={props.setConfirmationCallback}
                   topics={props.topics.discussedTopics} currentDiscussionItem={props.topics.currentDiscussionItem} sessionId={props.sessionId} isModerator={props.isModerator} 
                   isAnyTopicActive={props.topics.currentDiscussionItem !== undefined && props.topics.currentDiscussionItem.text !== undefined}/>
-              : <Current topic={props.topics.currentDiscussionItem}/>}
+              : <Current setIsAlertVisible={props.setIsAlertVisible} setAlertText={props.setAlertText} setConfirmationCallback={props.setConfirmationCallback}
+                  topic={props.topics.currentDiscussionItem} isModerator={props.isModerator} currentDiscussionItem={props.topics.currentDiscussionItem}
+                  sessionId={props.sessionId} discussionBacklogTopics={props.topics.discussionBacklogTopics}/>}
       </div>
     </div>
   )

--- a/src/session/discussion/Past.js
+++ b/src/session/discussion/Past.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import TopicCard from '../TopicCard'
+import DiscussionTopicFooter from './DiscussionTopicFooter'
+
+export default function Past(props) {
+
+  let createDisplay = () => {
+    if (props.topics === undefined || props.topics.length < 1) {
+      return <h3>Topics will appear here after they've been discussed</h3>
+    } else {
+      return (
+        <>
+          {props.topics.map((topic, i) => { 
+            let backlogTopicFooter = (
+              <DiscussionTopicFooter setAlertText={props.setAlertText} setIsAlertVisible={props.setIsAlertVisible} topic={topic} isAnyTopicActive={true}
+                setConfirmationCallback={props.setConfirmationCallback} sessionId={props.sessionId} isModerator={props.isModerator} currentDiscussionItem={props.currentDiscussionItem}/>)
+            return (
+              <div  className="p-2" key={i}>
+                <TopicCard topicBody={topic.text} topicFooter={backlogTopicFooter} makeAllWide={true}/>
+              </div>
+          )})}
+        </>
+      )
+    }
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="mt-2">
+        <h2>Past Topics</h2>
+      </div>
+
+      <div className="h-full overflow-scroll">
+        {createDisplay()}
+      </div>
+    </div>
+  )
+}

--- a/src/session/discussion/Past.js
+++ b/src/session/discussion/Past.js
@@ -6,7 +6,7 @@ export default function Past(props) {
 
   let createDisplay = () => {
     if (props.topics === undefined || props.topics.length < 1) {
-      return <h1>Topics will appear here after they've been discussed</h1>
+      return <h1 className="mt-2">Topics will appear here after they've been discussed</h1>
     } else {
       return (
         <>

--- a/src/session/discussion/Past.js
+++ b/src/session/discussion/Past.js
@@ -6,7 +6,7 @@ export default function Past(props) {
 
   let createDisplay = () => {
     if (props.topics === undefined || props.topics.length < 1) {
-      return <h3>Topics will appear here after they've been discussed</h3>
+      return <h1>Topics will appear here after they've been discussed</h1>
     } else {
       return (
         <>

--- a/src/session/discussion/Queue.js
+++ b/src/session/discussion/Queue.js
@@ -33,7 +33,7 @@ export default function Queue(props) {
 
   let createBacklog = () => {
     if (props.topics === undefined || 1 > props.topics.length ) {
-      return <h1>You've cleared out the discussion queue!</h1>
+      return <h1 className="mt-2">You've cleared out the discussion queue!</h1>
     } else if (2 <= props.topics.length && props.isModerator === true) {
       return (
         <div className="h-full">

--- a/src/session/discussion/Queue.js
+++ b/src/session/discussion/Queue.js
@@ -33,7 +33,7 @@ export default function Queue(props) {
 
   let createBacklog = () => {
     if (props.topics === undefined || 1 > props.topics.length ) {
-      return <h3>You've cleared out the discussion queue!</h3>
+      return <h1>You've cleared out the discussion queue!</h1>
     } else if (2 <= props.topics.length && props.isModerator === true) {
       return (
         <div className="h-full">


### PR DESCRIPTION
* add past tab page which display list of past topics, moderator can delete past topics or pull any past topic for discussion
* add session control buttons in current topic tab page, allowing moderator to end topic or end session
* wire up end session, non-moderators get alerted when session ends
* fix timer, set timer string in useEffect of React Hooks was weird, use class paradigm for just that component and make use of componentDidMount for timer control
* fix queue/current/past tabs a11y